### PR TITLE
refine deploy and refine config targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,6 @@
 # Test for minimum required CMake version 2.8.12
 cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
-
-
 #
 # Project description and (meta) information
 #
@@ -17,6 +15,12 @@ set(META_AUTHOR_ORGANIZATION "hpicgs group")
 set(META_AUTHOR_DOMAIN       "https://github.com/hpicgs/cmake-init/")
 set(META_AUTHOR_MAINTAINER   "daniel.limberger@hpi.uni-potsdam.de")
 
+string(TOUPPER ${META_PROJECT_NAME} META_PROJECT_NAME_UPPER)
+
+
+# Limit supported configuration types
+set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Limited Configs" FORCE)
+
 # Set project name and type (C/C++)
 project(${META_PROJECT_NAME} C CXX)
 
@@ -26,11 +30,16 @@ project(${META_PROJECT_NAME} C CXX)
 #
 # Configuration options
 #
-option(OPTION_LIMIT_CONFIGS "Generate limited configs (Release; Debug)." ON)
 option(OPTION_PORTABLE_INSTALL "Install into a self-contained directory." OFF)
-option(OPTION_BUILD_SHARED_LIBS "Build shared libraries (affects CMake variable BUILD_SHARED_LIBS)." ON)
+option(OPTION_BUILD_STATIC "Build static libraries." OFF)
 option(OPTION_BUILD_TESTS "Build tests (if gmock and gtest are found)." ON)
-set(BUILD_SHARED_LIBS $OPTION_BUILD_SHARED_LIBS)
+
+if(OPTION_BUILD_STATIC)
+   set(BUILD_SHARED_LIBS OFF)
+   message("Note: ${META_PROJECT_NAME_UPPER}_STATIC needs to be defined for static linking.")
+else()
+    set(BUILD_SHARED_LIBS ON)
+endif()
 
 
 
@@ -45,17 +54,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-
-# Set configuration types
-if(OPTION_LIMIT_CONFIGS)
-    set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Limited Configs" FORCE)
-endif()
-set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build, options are: ${CMAKE_CONFIGURATION_TYPES}")
-# Reorder CMAKE_CONFIGURATION_TYPES list so that the chosen CMAKE_BUILD_TYPE is the first element.
-if (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "")
-    list(REMOVE_ITEM CMAKE_CONFIGURATION_TYPES "${CMAKE_BUILD_TYPE}")
-    list(INSERT CMAKE_CONFIGURATION_TYPES 0 "${CMAKE_BUILD_TYPE}")
-endif()
 
 
 # Generate folders for IDE targets (e.g., VisualStudio solutions)

--- a/source/fibcmd/CMakeLists.txt
+++ b/source/fibcmd/CMakeLists.txt
@@ -31,6 +31,14 @@ set(libs
 )
 
 #
+# Compiler definitions
+#
+
+if (OPTION_BUILD_STATIC)
+    add_definitions("-D${META_PROJECT_NAME_UPPER}_STATIC")
+endif()
+
+#
 # Sources
 #
 

--- a/source/fiblib/CMakeLists.txt
+++ b/source/fiblib/CMakeLists.txt
@@ -34,7 +34,7 @@ set(libs
 #
 
 if (OPTION_BUILD_STATIC)
-    add_definitions("-DTEMPLATE_STATIC")
+    add_definitions("-D${META_PROJECT_NAME_UPPER}_STATIC")
 else()
     add_definitions("-DFIBLIB_EXPORTS")
 endif()
@@ -67,11 +67,7 @@ source_group_by_path(${source_path} "\\\\.cpp$|\\\\.c$|\\\\.h$|\\\\.hpp$"
 # Build library
 #
 
-if(OPTION_BUILD_STATIC)
-    add_library(${target} ${api_includes} ${sources})
-else()
-    add_library(${target} SHARED ${api_includes} ${sources})
-endif()
+add_library(${target} ${api_includes} ${sources})
 
 target_link_libraries(${target} ${libs})
 

--- a/source/fiblib/include/fiblib/fiblib_api.h
+++ b/source/fiblib/include/fiblib/fiblib_api.h
@@ -13,7 +13,7 @@
 #else
 #   define FIBLIB_API_EXPORT_DECLARATION
 #   define FIBLIB_API_IMPORT_DECLARATION
-#endif
+#endif 
 
 #ifndef TEMPLATE_STATIC
 #ifdef FIBLIB_EXPORTS

--- a/source/tests/fiblib-test/CMakeLists.txt
+++ b/source/tests/fiblib-test/CMakeLists.txt
@@ -26,6 +26,14 @@ set(libs
 )
 
 #
+# Compiler definitions
+#
+
+if (OPTION_BUILD_STATIC)
+    add_definitions("-D${META_PROJECT_NAME_UPPER}_STATIC")
+endif()
+
+#
 # Sources
 #
 


### PR DESCRIPTION
- use `BUILD_SHARED_LIBS` for add_library specification
- discard config sorting
- refine static/dynamic linking behavior (intentionally not utilizing `generate_export_header`)
