### PR TITLE
Enable multi-test setup

### DIFF
--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -9,9 +9,11 @@ endif()
 function(add_test_without_ctest target)
 
     add_subdirectory(${target})
-    add_dependencies(test ${target})
-    add_custom_command(TARGET test POST_BUILD 
-        COMMAND $<TARGET_FILE:${target}> --gtest_output=xml:gtests.xml)
+    if (TARGET ${target})
+        add_dependencies(test ${target})
+        add_custom_command(TARGET test POST_BUILD 
+           COMMAND $<TARGET_FILE:${target}> --gtest_output=xml:gtests-${target}.xml)
+    endif()
 
 endfunction()
 


### PR DESCRIPTION
This PR consists of two small changes to optimize testing with cmake and gmock / gtest.
First, after the sudirectory include it is tested if the appropriate target exists, so that the cmake script doesn't crash and the subdirectory script has the possibility to omit test target creation (e.g., because dependencies aren't available).
Second, the output xml file for the test results *must* be different for all included tests so that the next executed test case doesn't overwrite the previous results.