### PR TITLE
Refine configure script

### DIFF
--- a/configure
+++ b/configure
@@ -27,16 +27,16 @@ then
     echo "#CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DCMAKE_INSTALL_PREFIX=../install\"" >> ".localconfig/default"
     echo "" >> ".localconfig/default"
     echo "# Build static libraries" >> ".localconfig/default"
-    echo "#CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DBUILD_SHARED_LIBS=OFF\"" >> ".localconfig/default"
+    echo "#CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DBUILD_SHARED_LIBS:BOOL=OFF\"" >> ".localconfig/default"
     echo "" >> ".localconfig/default"
     echo "# Enable examples" >> ".localconfig/default"
-    echo "#CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DOPTION_BUILD_EXAMPLES=ON\"" >> ".localconfig/default"
+    echo "#CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DOPTION_BUILD_EXAMPLES:BOOL=ON\"" >> ".localconfig/default"
     echo "" >> ".localconfig/default"
     echo "# Enable documentation" >> ".localconfig/default"
-    echo "#CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DOPTION_BUILD_DOCS=ON\"" >> ".localconfig/default"
+    echo "#CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DOPTION_BUILD_DOCS:BOOL=ON\"" >> ".localconfig/default"
     echo "" >> ".localconfig/default"
     echo "# Disable tests" >> ".localconfig/default"
-    echo "#CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DOPTION_BUILD_TESTS=OFF\"" >> ".localconfig/default"
+    echo "#CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DOPTION_BUILD_TESTS:BOOL=OFF\"" >> ".localconfig/default"
     echo "" >> ".localconfig/default"
     echo "" >> ".localconfig/default"
     echo "# CMake and environment variables (e.g., search paths for external libraries)" >> ".localconfig/default"
@@ -62,16 +62,18 @@ then
     echo "CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DCMAKE_INSTALL_PREFIX=/usr\"" >> ".localconfig/pack"
     echo "" >> ".localconfig/pack"
     echo "# Enable self-contained installation" >> ".localconfig/pack"
-    echo "#CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DOPTION_SELF_CONTAINED=ON\"" >> ".localconfig/pack"
+    echo "#CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DOPTION_SELF_CONTAINED:BOOL=ON\"" >> ".localconfig/pack"
     echo "" >> ".localconfig/pack"
     echo "# Enable all components for the package" >> ".localconfig/pack"
-    echo "CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DOPTION_BUILD_EXAMPLES=ON\"" >> ".localconfig/pack"
-    echo "CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DOPTION_BUILD_DOCS=ON\"" >> ".localconfig/pack"
-    echo "CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DOPTION_BUILD_TESTS=OFF\"" >> ".localconfig/pack"
+    echo "CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DOPTION_BUILD_EXAMPLES:BOOL=ON\"" >> ".localconfig/pack"
+    echo "CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DOPTION_BUILD_DOCS:BOOL=ON\"" >> ".localconfig/pack"
+    echo "CMAKE_OPTIONS=\"\${CMAKE_OPTIONS} -DOPTION_BUILD_TESTS:BOOL=OFF\"" >> ".localconfig/pack"
 
     echo "Default configuration has been written to .localconfig"
     echo "Please review and adjust the configuration, then run again"
-    echo "  ./configure"
+    echo ""
+    echo "  ./configure $@"
+    
     exit
 fi
 
@@ -86,14 +88,20 @@ for ARG in "$@"
 do
     # Read in configuration for that command-line argument
     CONFIGFILE="./.localconfig/$ARG"
-    if [ -f "$CONFIGFILE" ]
+    if [ -f "./.localconfig/$ARG" ]
     then
-        . "$CONFIGFILE"
+        . "./.localconfig/$ARG"
+    elif [ -f "~/.localconfig/$ARG" ]
+    then
+        . "~/.localconfig/$ARG"
+    else
+        echo "Configuration \"$ARG\" not found (searched in ./.localconfig and ~/.localconfig)"
     fi
 done
 
 # Configure build
 echo "Configuring ..."
+echo ""
 
 # Create build directory
 if [ ! -d "./$BUILD_DIR" ]
@@ -106,10 +114,12 @@ cd $BUILD_DIR
 cmake -G "$CMAKE_GENERATOR" "-DCMAKE_BUILD_TYPE=$BUILD_TYPE" $CMAKE_OPTIONS ..
 if [ $? == 0 ]
 then
+    echo ""
     echo "Project configured. To build the project, use";
-    echo "  cd $BUILD_DIR"
-    echo "  make"
+    echo ""
+    echo "  cmake --build $BUILD_DIR"
 else
+    echo ""
     echo "Configuration failed.";
 fi
 


### PR DESCRIPTION
* define cmake variable type for booleans
* insert empty lines around commands to execute by user (additionally inserting them into the command history failed)
* output all passed parameters from first configure into the command prompt for the subsequent configure calls
* search for configuration scripts also in the users home directory
* print an error if no configuration script was found
* use cmake build command instead of manual cd and make