### PR TITLE
Emulate DESTDIR behavior for per-component PPA deployment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,10 @@ option(OPTION_BUILD_TESTS    "Build tests."                                     
 option(OPTION_BUILD_DOCS     "Build documentation."                                   OFF)
 option(OPTION_BUILD_EXAMPLES "Build examples."                                        OFF)
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    set(OPTION_DEPLOY_DESTDIR "" CACHE STRING "Emulates the DESTDIR convention of make install.")
+endif()
+
 
 # 
 # Declare project

--- a/deploy/packages/pack-template.cmake
+++ b/deploy/packages/pack-template.cmake
@@ -247,6 +247,18 @@ add_custom_target(
 )
 set_target_properties(pack-${project_name} PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
 
+# Create per-component install targets
+if(OPTION_DEPLOY_DESTDIR AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    foreach(component ${CPACK_COMPONENTS_ALL})
+        add_custom_target(
+            destdir-deploy-${component}
+	    COMMAND make preinstall
+	    COMMAND DESTDIR=${OPTION_DEPLOY_DESTDIR} ${CMAKE_COMMAND} -DCOMPONENT=${component} -P cmake_install.cmake
+            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        )
+    endforeach()
+endif()
+
 # Set dependencies
 add_dependencies(pack pack-${project_name})
 if(MSVC)


### PR DESCRIPTION
This enables the combination of the ```-DCMAKE_INSTALL_COMPONENT``` variable with the ```DESTDIR``` convention of GNU ```make install``` (https://www.gnu.org/prep/standards/html_node/DESTDIR.html).

The CMake ```OPTION_DEPLOY_DESTDIR``` *option* (actually, a cached string variable) is added for Linux systems that takes the value of the ```DESTDIR``` parameter/macro/environment variable and generates one target per component (```destdir-deploy-${component}```) that calls the ```preinstall``` target and later executes the install with the ```DESTDIR``` construct and the current component.

With this extension it is possible to deploy only parts of the CMake components for a debian source package. A typical workflow would be:
```bash
> cd build
build > cmake .. -DOPTION_DEPLOY_DESTDIR=debian/tmp
build > make destdir-deploy-runtime
build > cd ..
> dpkg-gencontrol -pcmake-init
> dpkg --build debian/tmp
```