### PR TITLE
Fix packaging for non-"Release" builds on multi-configuration generators

### DIFF
--- a/deploy/packages/pack-template.cmake
+++ b/deploy/packages/pack-template.cmake
@@ -250,7 +250,7 @@ include(CPack)
 # Create target
 add_custom_target(
     pack-${project_name}
-    COMMAND ${CPACK_COMMAND} --config ${PROJECT_BINARY_DIR}/CPackConfig-${project_name}.cmake
+    COMMAND ${CPACK_COMMAND} --config ${PROJECT_BINARY_DIR}/CPackConfig-${project_name}.cmake -C $<CONFIG>
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
 )
 set_target_properties(pack-${project_name} PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)


### PR DESCRIPTION
In Visual Studio etc. CPack defaults Release packages when no configuration is specified, even if a different build type is selected in the IDE. With Makefile/Ninja generators, this should make any difference.

@cgcostume This should partly fix the debug packaging problems mentioned in https://github.com/cginternals/glbinding/issues/168
