### PR TITLE
Adapt FindGLFW script to find from precompiled windows package

### DIFF
--- a/cmake/FindGLFW.cmake
+++ b/cmake/FindGLFW.cmake
@@ -26,7 +26,35 @@ find_path(GLFW_INCLUDE_DIR GLFW/glfw3.h
 
     DOC "The directory where GLFW/glfw.h resides")
 
-find_library(GLFW_LIBRARY_RELEASE NAMES glfw3 glfw glfw3dll glfwdll
+
+set(GLFW_LIB_SUFFIX "")
+if(MSVC14)
+    set(GLFW_LIB_SUFFIX "vc2015")
+elseif(MSVS12)
+    set(GLFW_LIB_SUFFIX "vc2013")
+elseif(MSVC11)
+    set(GLFW_LIB_SUFFIX "vc2012")
+elseif(MSVC10)
+    set(GLFW_LIB_SUFFIX "vc2010")
+elseif(MINGW)
+    if(X64)
+        set(GLFW_LIB_SUFFIX "mingw-w64")
+    else()
+        set(GLFW_LIB_SUFFIX "mingw")
+    endif()
+endif()
+
+set(GLFW_NAMES glfw3 glfw)
+set(GLFW_DEBUG_NAMES glfw3d glfwd)
+if(WIN32)
+    option(GLFW_SHARED "Use shared GLFW library (DLL)" ON)
+    if(GLFW_SHARED)
+        set(GLFW_NAMES glfw3dll glfwdll)
+        set(GLFW_DEBUG_NAMES glfw3ddll glfwddll)
+    endif()
+endif()
+
+find_library(GLFW_LIBRARY_RELEASE NAMES ${GLFW_NAMES}
 
     HINTS
     ${GLFW_INCLUDE_DIR}/..
@@ -49,11 +77,12 @@ find_library(GLFW_LIBRARY_RELEASE NAMES glfw3 glfw glfw3dll glfwdll
     PATH_SUFFIXES
     /lib
     /lib64
+    /lib-${GLFW_LIB_SUFFIX}
     /src # for from-source builds
 
     DOC "The GLFW library")
 
-find_library(GLFW_LIBRARY_DEBUG NAMES glfw3d glfwd glfw3ddll glfwddll
+find_library(GLFW_LIBRARY_DEBUG NAMES ${GLFW_DEBUG_NAMES}
 
     HINTS
     ${GLFW_INCLUDE_DIR}/..
@@ -91,7 +120,7 @@ elseif(GLFW_LIBRARY_DEBUG)
     set(GLFW_LIBRARIES ${GLFW_LIBRARY_DEBUG})
 endif()
 
-if(WIN32)
+if(WIN32 AND GLFW_SHARED)
 
     find_file(GLFW_BINARY glfw3.dll
 
@@ -106,6 +135,7 @@ if(WIN32)
         PATH_SUFFIXES
         /lib
         /bin
+        /lib-${GLFW_LIB_SUFFIX}
 
         DOC "The GLFW binary")
 


### PR DESCRIPTION
Precompiled GLFW comes with the following directory structure:

```
glfw-3.2.1.bin.WIN64
|--- include
|--- lib-mingw-w64
|    |--- glfw3.dll
|    |--- glfw3.a
|    |--- glfw3dll.a
|--- lib-vc2012
|    |--- glfw3.dll
|    |--- glfw3.lib
|    |--- glfw3dll.lib
|--- lib-vc2013
|    |--- ...
|--- lib-vc2015
     |--- ...
```

x86 package has `lib-mingw` instead of `lib-mingw-w64` and additionally `lib-vc2010` directory
