### PR TITLE
Rewrite FindFFMPEG to support Windows systems

### DIFF
--- a/cmake/FindFFMPEG.cmake
+++ b/cmake/FindFFMPEG.cmake
@@ -1,76 +1,172 @@
 
-# - Try to find ffmpeg libraries (libavcodec, libavformat and libavutil)
-# Once done this will define
-#
-#  FFMPEG_FOUND - system has ffmpeg or libav
-#  FFMPEG_INCLUDE_DIR - the ffmpeg include directory
-#  FFMPEG_LIBRARIES - Link these to use ffmpeg
-#  FFMPEG_LIBAVCODEC
-#  FFMPEG_LIBAVFORMAT
-#  FFMPEG_LIBAVUTIL
-#  FFMPEG_LIBSWSCALE
-#
-#  Copyright (c) 2008 Andreas Schneider <mail@cynapses.org>
-#  Modified for other libraries by Lasse Kärkkäinen <tronic>
-#  Modified for Hedgewars by Stepik777
-#
-#  Redistribution and use is allowed according to the terms of the New
-#  BSD license.
-#
+# FFMPEG_FOUND
+# FFMPEG_INCLUDE_DIR
+# FFMPEG_LIBRARIES
+# FFMPEG_BINARIES (win32 only)
 
-if (FFMPEG_LIBRARIES AND FFMPEG_INCLUDE_DIR)
-  # in cache already
-  set(FFMPEG_FOUND TRUE)
-else (FFMPEG_LIBRARIES AND FFMPEG_INCLUDE_DIR)
-  find_path(FFMPEG_AVCODEC_INCLUDE_DIR
-    NAMES libavcodec/avcodec.h
-    PATHS ${_FFMPEG_AVCODEC_INCLUDE_DIRS} /usr/include /usr/local/include /opt/local/include /sw/include
-    PATH_SUFFIXES ffmpeg libav
-  )
+# FFMPEG_AVCODEC_LIBRARY_RELEASE
+# FFMPEG_AVCODEC_LIBRARY_DEBUG
+# FFMPEG_AVCODEC_LIBRARIES
+# FFMPEG_AVCODEC_BINARY (win32 only)
 
-  find_library(FFMPEG_LIBAVCODEC
-    NAMES avcodec
-    PATHS ${_FFMPEG_AVCODEC_LIBRARY_DIRS} /usr/lib /usr/local/lib /opt/local/lib /sw/lib
-  )
+# FFMPEG_AVDEVICE_LIBRARY_RELEASE
+# FFMPEG_AVDEVICE_LIBRARY_DEBUG
+# FFMPEG_AVDEVICE_LIBRARIES
+# FFMPEG_AVDEVICE_BINARY (win32 only)
 
-  find_library(FFMPEG_LIBAVFORMAT
-    NAMES avformat
-    PATHS ${_FFMPEG_AVFORMAT_LIBRARY_DIRS} /usr/lib /usr/local/lib /opt/local/lib /sw/lib
-  )
+# FFMPEG_AVFILTER_LIBRARY_RELEASE
+# FFMPEG_AVFILTER_LIBRARY_DEBUG
+# FFMPEG_AVFILTER_LIBRARIES
+# FFMPEG_AVFILTER_BINARY (win32 only)
 
-  find_library(FFMPEG_LIBAVUTIL
-    NAMES avutil
-    PATHS ${_FFMPEG_AVUTIL_LIBRARY_DIRS} /usr/lib /usr/local/lib /opt/local/lib /sw/lib
-  )
+# FFMPEG_AVFORMAT_LIBRARY_RELEASE
+# FFMPEG_AVFORMAT_LIBRARY_DEBUG
+# FFMPEG_AVFORMAT_LIBRARIES
+# FFMPEG_AVFORMAT_BINARY (win32 only)
 
-  find_library(FFMPEG_LIBSWSCALE
-    NAMES swscale
-    PATHS ${_FFMPEG_SWSCALE_LIBRARY_DIRS} /usr/lib /usr/local/lib /opt/local/lib /sw/lib
-  )
+# FFMPEG_AVUTIL_LIBRARY_RELEASE
+# FFMPEG_AVUTIL_LIBRARY_DEBUG
+# FFMPEG_AVUTIL_LIBRARIES
+# FFMPEG_AVUTIL_BINARY (win32 only)
 
-  if (FFMPEG_LIBAVCODEC AND FFMPEG_LIBAVFORMAT)
-    set(FFMPEG_FOUND TRUE)
-  endif()
+# FFMPEG_POSTPROC_LIBRARY_RELEASE
+# FFMPEG_POSTPROC_LIBRARY_DEBUG
+# FFMPEG_POSTPROC_LIBRARIES
+# FFMPEG_POSTPROC_BINARY (win32 only)
 
-  if (FFMPEG_FOUND)
-    set(FFMPEG_INCLUDE_DIR ${FFMPEG_AVCODEC_INCLUDE_DIR})
+# FFMPEG_SWRESAMPLE_LIBRARY_RELEASE
+# FFMPEG_SWRESAMPLE_LIBRARY_DEBUG
+# FFMPEG_SWRESAMPLE_LIBRARIES
+# FFMPEG_SWRESAMPLE_BINARY (win32 only)
 
-    set(FFMPEG_LIBRARIES
-      ${FFMPEG_LIBAVCODEC}
-      ${FFMPEG_LIBAVFORMAT}
-      ${FFMPEG_LIBAVUTIL}
-    )
+# FFMPEG_SWSCALE_LIBRARY_RELEASE
+# FFMPEG_SWSCALE_LIBRARY_DEBUG
+# FFMPEG_SWSCALE_LIBRARIES
+# FFMPEG_SWSCALE_BINARY (win32 only)
 
-  endif (FFMPEG_FOUND)
+include(FindPackageHandleStandardArgs)
 
-  if (FFMPEG_FOUND)
-    if (NOT FFMPEG_FIND_QUIETLY)
-      message(STATUS "Found FFMPEG or Libav: ${FFMPEG_LIBRARIES}, ${FFMPEG_INCLUDE_DIR}")
-    endif (NOT FFMPEG_FIND_QUIETLY)
-  else (FFMPEG_FOUND)
-    if (FFMPEG_FIND_REQUIRED)
-      message(FATAL_ERROR "Could not find libavcodec or libavformat or libavutil")
-    endif (FFMPEG_FIND_REQUIRED)
-  endif (FFMPEG_FOUND)
 
-endif (FFMPEG_LIBRARIES AND FFMPEG_INCLUDE_DIR)
+set(FFMPEG_LIBRARIES "")
+if(WIN32)
+    set(FFMPEG_BINARIES "")
+endif()
+
+
+macro(find_component NAME)
+    
+    string(TOUPPER ${NAME} NAME_UPPER)
+
+    # find release library
+    find_library(FFMPEG_${NAME_UPPER}_LIBRARY_RELEASE NAMES ${NAME}
+        
+        HINTS
+        ${FFMPEG_INCLUDE_DIR}/..
+        
+        PATHS
+        $ENV{FFMPEG_DIR}
+        /usr
+        /usr/local
+        /sw
+        /opt/local
+
+        PATH_SUFFIXES
+        /lib
+        /build/code
+        /build-debug/code
+
+        DOC "The ${NAME} library (release)")
+
+    # find debug library
+    find_library(FFMPEG_${NAME_UPPER}_LIBRARY_DEBUG NAMES "${NAME}d"
+        
+        HINTS
+        ${FFMPEG_INCLUDE_DIR}/..
+
+        PATHS
+        $ENV{FFMPEG_DIR}
+        /usr
+        /usr/local
+        /sw
+        /opt/local
+
+        PATH_SUFFIXES
+        /lib
+        /build/code
+        /build-debug/code
+
+        DOC "The ${NAME} library (debug)")
+
+    set(FFMPEG_${NAME_UPPER}_LIBRARIES "")
+    if(FFMPEG_${NAME_UPPER}_LIBRARY_RELEASE AND FFMPEG_${NAME_UPPER}_LIBRARY_DEBUG)
+        set(FFMPEG_${NAME_UPPER}_LIBRARIES 
+            optimized   ${FFMPEG_${NAME_UPPER}_LIBRARY_RELEASE}
+            debug       ${FFMPEG_${NAME_UPPER}_LIBRARY_DEBUG})
+    elseif(FFMPEG_${NAME_UPPER}_LIBRARY_RELEASE)
+        set(FFMPEG_${NAME_UPPER}_LIBRARIES ${FFMPEG_${NAME_UPPER}_LIBRARY_RELEASE})
+    elseif(FFMPEG_${NAME_UPPER}_LIBRARY_DEBUG)
+        set(FFMPEG_${NAME_UPPER}_LIBRARIES ${FFMPEG_${NAME_UPPER}_LIBRARY_DEBUG})
+    endif()
+    list(APPEND FFMPEG_LIBRARIES ${FFMPEG_${NAME_UPPER}_LIBRARIES})
+
+    # find DLL
+    if(WIN32)
+        
+        # parse versio.h to find major version
+        file(READ "${FFMPEG_INCLUDE_DIR}/lib${NAME}/version.h" content)
+        string(REGEX MATCH ".*LIB${NAME_UPPER}_VERSION_MAJOR +([0-9]+).*" TMP ${content})
+        set(DLL_VERSION ${CMAKE_MATCH_1})
+
+        find_file(FFMPEG_${NAME_UPPER}_BINARY NAMES "${NAME}-${DLL_VERSION}.dll" "${NAME}.dll"
+
+            HINTS
+            ${FFMPEG_INCLUDE_DIR}/..
+            
+            PATHS
+            $ENV{FFMPEG_DIR}
+            $ENV{FFMPEG_BIN_DIR}
+
+            PATH_SUFFIXES
+            /bin
+
+            DOC "The ${NAME} binary")
+
+        list(APPEND FFMPEG_BINARIES ${FFMPEG_${NAME_UPPER}_BINARY})
+
+    endif()
+
+    find_package_handle_standard_args(FFMPEG_${NAME} DEFAULT_MSG FFMPEG_${NAME_UPPER}_LIBRARIES)
+    
+endmacro(find_component)
+
+
+# find include path
+find_path(FFMPEG_INCLUDE_DIR libavcodec/avcodec.h
+
+    PATHS
+    $ENV{FFMPEG_DIR}
+    /usr
+    /usr/local
+    /sw
+    /opt/local
+
+    PATH_SUFFIXES
+    /include
+
+    DOC "The directory where libavcodec/avcodec.h resides")
+
+
+# Load components
+set(AVAILABLE_COMPONENTS avcodec avdevice avfilter avformat avutil postproc swresample swscale)
+foreach(COMPONENT ${FFMPEG_FIND_COMPONENTS})
+    list(FIND AVAILABLE_COMPONENTS ${COMPONENT} INDEX)
+    if(INDEX EQUAL -1)
+        message(FATAL_ERROR " Unknown component: ${COMPONENT}")
+    endif()
+    find_component(${COMPONENT})
+endforeach(COMPONENT)
+
+
+find_package_handle_standard_args(FFMPEG
+    REQUIRED_VARS FFMPEG_LIBRARIES FFMPEG_INCLUDE_DIR
+    HANDLE_COMPONENTS)


### PR DESCRIPTION
The find script uses components, i.e., `find_package(FFMPEG COMPONENTS avcodec avutil avformat swscale)`. Two environmental variables are used to find paths and libraries on Windows (`FFMPEG_DIR` and `FFMPEG_BIN_DIR`) because precompiled DLLs are shipped separately.

Needs testing on OS X and Linux.
