### PR TITLE
[WIP] Add stub to check targets using cppcheck

### DIFF
--- a/source/baselib/CMakeLists.txt
+++ b/source/baselib/CMakeLists.txt
@@ -182,6 +182,17 @@ target_link_libraries(${target}
 )
 
 
+#
+# Target Health
+#
+
+enable_cppcheck(
+    ${target}
+    ${sources}
+    ${headers}
+)
+
+
 # 
 # Deployment
 # 

--- a/source/examples/fibcmd/CMakeLists.txt
+++ b/source/examples/fibcmd/CMakeLists.txt
@@ -104,6 +104,16 @@ target_link_libraries(${target}
 )
 
 
+#
+# Target Health
+#
+
+enable_cppcheck(
+    ${target}
+    ${sources}
+)
+
+
 # 
 # Deployment
 # 

--- a/source/examples/fibgui/CMakeLists.txt
+++ b/source/examples/fibgui/CMakeLists.txt
@@ -127,6 +127,16 @@ target_link_libraries(${target}
 )
 
 
+#
+# Target Health
+#
+
+enable_cppcheck(
+    ${target}
+    ${sources}
+)
+
+
 # 
 # Deployment
 # 

--- a/source/fiblib/CMakeLists.txt
+++ b/source/fiblib/CMakeLists.txt
@@ -182,6 +182,17 @@ target_link_libraries(${target}
 )
 
 
+#
+# Target Health
+#
+
+enable_cppcheck(
+    ${target}
+    ${sources}
+    ${headers}
+)
+
+
 # 
 # Deployment
 # 


### PR DESCRIPTION
A proposal to add cppcheck tests for each target.
If cmake-init is meant to be a template for C++ projects, employing all parts of the development cycle, I think we can also support health-check use cases.

For my first use case, I want to use cppcheck in travis CI.
As cmake provides useful information about include paths and the full list of source files, I added the integration using cmake.

Concept:
* call a function (defined in Custom.cmake) for each target that should get checked by cppcheck
* A cmake target is created for each registered target
* Include directories are extracted from target, the list of sources has to be passed to the function
* Additionally, a cppcheck-all target is setup to execute cppchecks for all registered targets

Todo:
* [ ] Search for cppcheck first and default to warning messages if not found
* [ ] Add integration into travis.yml