### PR TITLE
Disable -Wreturn-stack-address for Clang

### DIFF
--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -119,7 +119,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCH
         $<$<CXX_COMPILER_ID:Clang>:
             -Wpedantic
             
-            -Wreturn-stack-address
+            # -Wreturn-stack-address # gives false positives
         >
         
         $<$<PLATFORM_ID:Darwin>:


### PR DESCRIPTION
Clang has some problems correctly detecting these, giving false positives.

See http://stackoverflow.com/questions/33736678/returning-reference-to-local-temporary-object-on-pointer-dereferencing

Currently, this affects `cppexpose::Variant<T>::value(const T & defaultValue = T())` where T is a pointer type. Returning the `defaultValue` pointer by-value is fine (as is copies the pointer value); however, Clang issues a "Returning address of local temporary object" warning.