### PR TITLE
Add explicit visibility for class and function templates (closes #56)

### DIFF
--- a/cmake/Custom.cmake
+++ b/cmake/Custom.cmake
@@ -44,3 +44,16 @@ function(list_extract OUTPUT REGEX)
     set(${OUTPUT} ${${OUTPUT}} PARENT_SCOPE)
 
 endfunction(list_extract)
+
+
+# Creates an export header similar to generate_export_header, but for templates.
+# The main difference is that for MSVC, templates must not get exported.
+# When the file ${export_file} is included in source code, the macro ${target_id}_TEMPLATE_API
+# may get used to define public visibility for templates on GCC and Clang platforms.
+function(generate_template_export_header target target_id export_file)
+    if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+        configure_file(${PROJECT_SOURCE_DIR}/source/codegeneration/template_msvc_api.h.in ${CMAKE_CURRENT_BINARY_DIR}/${export_file})
+    else()
+        configure_file(${PROJECT_SOURCE_DIR}/source/codegeneration/template_api.h.in ${CMAKE_CURRENT_BINARY_DIR}/${export_file})
+    endif()
+endfunction()

--- a/source/baselib/CMakeLists.txt
+++ b/source/baselib/CMakeLists.txt
@@ -19,9 +19,10 @@ message(STATUS "Lib ${target}")
 # Set API export file and macro
 string(MAKE_C_IDENTIFIER ${target} target_id)
 string(TOUPPER ${target_id} target_id)
-set(feature_file "include/${target}/${target}_features.h")
-set(export_file  "include/${target}/${target}_api.h")
-set(export_macro "${target_id}_API")
+set(feature_file         "include/${target}/${target}_features.h")
+set(export_file          "include/${target}/${target}_export.h")
+set(template_export_file "include/${target}/${target}_api.h")
+set(export_macro         "${target_id}_API")
 
 
 # 
@@ -89,6 +90,10 @@ endif()
 generate_export_header(${target}
     EXPORT_FILE_NAME  ${export_file}
     EXPORT_MACRO_NAME ${export_macro}
+)
+generate_template_export_header(${target}
+    ${target_id}
+    ${template_export_file}
 )
 
 

--- a/source/codegeneration/template_api.h.in
+++ b/source/codegeneration/template_api.h.in
@@ -6,7 +6,6 @@
 
 #ifdef ${target_id}_STATIC_DEFINE
 #  define ${target_id}_TEMPLATE_API
-#  define ${target_id}_TEMPLATE_NO_EXPORT
 #else
 #  ifndef ${target_id}_TEMPLATE_API
 #    ifdef ${target}_EXPORTS

--- a/source/codegeneration/template_api.h.in
+++ b/source/codegeneration/template_api.h.in
@@ -1,0 +1,23 @@
+
+#ifndef ${target_id}_TEMPLATE_API_H
+#define ${target_id}_TEMPLATE_API_H
+
+#include <${target}/${target}_export.h>
+
+#ifdef ${target_id}_STATIC_DEFINE
+#  define ${target_id}_TEMPLATE_API
+#  define ${target_id}_TEMPLATE_NO_EXPORT
+#else
+#  ifndef ${target_id}_TEMPLATE_API
+#    ifdef ${target}_EXPORTS
+        /* We are building this library */
+#      define ${target_id}_TEMPLATE_API __attribute__((visibility("default")))
+#    else
+        /* We are using this library */
+#      define ${target_id}_TEMPLATE_API __attribute__((visibility("default")))
+#    endif
+#  endif
+
+#endif
+
+#endif

--- a/source/codegeneration/template_msvc_api.in
+++ b/source/codegeneration/template_msvc_api.in
@@ -6,7 +6,6 @@
 
 #ifdef ${target_id}_STATIC_DEFINE
 #  define ${target_id}_TEMPLATE_API
-#  define ${target_id}_TEMPLATE_NO_EXPORT
 #else
 #  ifndef ${target_id}_TEMPLATE_API
 #    ifdef ${target}_EXPORTS

--- a/source/codegeneration/template_msvc_api.in
+++ b/source/codegeneration/template_msvc_api.in
@@ -1,0 +1,23 @@
+
+#ifndef ${target_id}_TEMPLATE_API_H
+#define ${target_id}_TEMPLATE_API_H
+
+#include <${target}/${target}_export.h>
+
+#ifdef ${target_id}_STATIC_DEFINE
+#  define ${target_id}_TEMPLATE_API
+#  define ${target_id}_TEMPLATE_NO_EXPORT
+#else
+#  ifndef ${target_id}_TEMPLATE_API
+#    ifdef ${target}_EXPORTS
+        /* We are building this library */
+#      define ${target_id}_TEMPLATE_API
+#    else
+        /* We are using this library */
+#      define ${target_id}_TEMPLATE_API
+#    endif
+#  endif
+
+#endif
+
+#endif

--- a/source/examples/fibcmd/main.cpp
+++ b/source/examples/fibcmd/main.cpp
@@ -3,6 +3,7 @@
 
 #include <baselib/baselib.h>
 
+#include <fiblib/CTFibonacci.h>
 #include <fiblib/Fibonacci.h>
 
 
@@ -15,7 +16,8 @@ int main(int /*argc*/, char* /*argv*/[])
     // Calculate and print fibonacci number
     std::cout << "Fibonacci library" << std::endl;
     std::cout << "========================================" << std::endl;
-    std::cout << "Fibonacci(8) = " << fiblib::Fibonacci()(8) << std::endl;
+    std::cout << "CTFibonacci(6) = " << fiblib::CTFibonacci<6>::value << std::endl;
+    std::cout << "Fibonacci(8)   = " << fiblib::Fibonacci()(8) << std::endl;
     std::cout << std::endl;
 
     return 0;

--- a/source/fiblib/CMakeLists.txt
+++ b/source/fiblib/CMakeLists.txt
@@ -19,9 +19,10 @@ message(STATUS "Lib ${target}")
 # Set API export file and macro
 string(MAKE_C_IDENTIFIER ${target} target_id)
 string(TOUPPER ${target_id} target_id)
-set(feature_file "include/${target}/${target}_features.h")
-set(export_file  "include/${target}/${target}_api.h")
-set(export_macro "${target_id}_API")
+set(feature_file         "include/${target}/${target}_features.h")
+set(export_file          "include/${target}/${target}_export.h")
+set(template_export_file "include/${target}/${target}_api.h")
+set(export_macro         "${target_id}_API")
 
 
 # 
@@ -32,6 +33,8 @@ set(include_path "${CMAKE_CURRENT_SOURCE_DIR}/include/${target}")
 set(source_path  "${CMAKE_CURRENT_SOURCE_DIR}/source")
 
 set(headers
+    ${include_path}/CTFibonacci.h
+    ${include_path}/CTFibonacci.inl
     ${include_path}/Fibonacci.h
 )
 
@@ -89,6 +92,10 @@ endif()
 generate_export_header(${target}
     EXPORT_FILE_NAME  ${export_file}
     EXPORT_MACRO_NAME ${export_macro}
+)
+generate_template_export_header(${target}
+    ${target_id}
+    ${template_export_file}
 )
 
 

--- a/source/fiblib/include/fiblib/CTFibonacci.h
+++ b/source/fiblib/include/fiblib/CTFibonacci.h
@@ -1,0 +1,29 @@
+
+#pragma once
+
+
+#include <fiblib/fiblib_api.h>
+
+
+namespace fiblib
+{
+
+
+/**
+*  @brief
+*    Compile-time computation of fibonacci numbers
+*/
+template <unsigned long long i>
+class FIBLIB_TEMPLATE_API CTFibonacci
+{
+public:
+    enum {
+        value = CTFibonacci<i-2>::value + CTFibonacci<i-1>::value
+    };
+};
+
+
+} // namespace fiblib
+
+
+#include <fiblib/CTFibonacci.inl>

--- a/source/fiblib/include/fiblib/CTFibonacci.inl
+++ b/source/fiblib/include/fiblib/CTFibonacci.inl
@@ -1,0 +1,28 @@
+
+#pragma once
+
+
+namespace fiblib
+{
+
+
+template <>
+class FIBLIB_TEMPLATE_API CTFibonacci<0>
+{
+public:
+    enum {
+        value = 0
+    };
+};
+
+template <>
+class FIBLIB_TEMPLATE_API CTFibonacci<1>
+{
+public:
+    enum {
+        value = 1
+    };
+};
+
+
+} // namespace fiblib


### PR DESCRIPTION
The current symbol visibility is implemented as follows:
* Symbols are hidden by default (default on Windows; enabled on Linux and macOS with `-fvisibility=hidden`)
* Symbols of the public API of a library are tagged using an `_API` macro
  * for MSVC this translates to dllexport and dllimport declarations with respect to the current compilation state
  * for GCC and clang this macro declares `default` visibility

Templates are not part of public interface as MSVC can't handle dllexport and dllimport on non-compiled symbols. Thus, we don't define visibility on templates and inline functions on Linux and macOS either and they are hidden by our default setting.

To solve the visibility problem between the compilers MSVC, GCC and clang (considering the platforms Windows, Linux and macOS), I propose the following additional visibility behavior:
* Differentiate between *normal* class and function visibility and template visibility
* Add a specific `_TEMPLATE_API` macro that resolves to default visibility on GCC and clang but to nothing on MSVC