### PR TITLE
Set EXCLUDE_FROM_DEFAULT_BUILD for maintenance targets

### DIFF
--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -17,6 +17,7 @@ function(perform_clang_tidy check_target target)
     set_target_properties(${check_target}
         PROPERTIES
         FOLDER "Maintenance"
+        EXCLUDE_FROM_DEFAULT_BUILD 1
     )
     
     add_dependencies(${check_target} ${target})

--- a/cmake/Cppcheck.cmake
+++ b/cmake/Cppcheck.cmake
@@ -21,7 +21,7 @@ function(perform_cppcheck check_target target)
     set_target_properties(${check_target}
         PROPERTIES
         FOLDER "Maintenance"
-        EXCLUDE_FROM_DEFAULT_BUILD 1)
+        EXCLUDE_FROM_DEFAULT_BUILD 1
     )
     
     add_dependencies(${check_target} ${target})

--- a/cmake/Cppcheck.cmake
+++ b/cmake/Cppcheck.cmake
@@ -21,6 +21,7 @@ function(perform_cppcheck check_target target)
     set_target_properties(${check_target}
         PROPERTIES
         FOLDER "Maintenance"
+        EXCLUDE_FROM_DEFAULT_BUILD 1)
     )
     
     add_dependencies(${check_target} ${target})

--- a/cmake/HealthCheck.cmake
+++ b/cmake/HealthCheck.cmake
@@ -13,10 +13,17 @@ function(perform_health_checks target)
         set_target_properties(check-all
             PROPERTIES
             FOLDER "Maintenance"
+            EXCLUDE_FROM_DEFAULT_BUILD 1
         )
     endif()
     
     add_custom_target(check-${target})
+    
+    set_target_properties(check-${target}
+        PROPERTIES
+        FOLDER "Maintenance"
+        EXCLUDE_FROM_DEFAULT_BUILD 1
+    )
     
     if (OPTION_CPPCHECK_ENABLED)
         perform_cppcheck(cppcheck-${target} ${target} ${ARGN})
@@ -92,5 +99,6 @@ function(add_check_template_target current_template_sha)
     set_target_properties(check-template
         PROPERTIES
         FOLDER "Maintenance"
+        EXCLUDE_FROM_DEFAULT_BUILD 1
     )
 endfunction()


### PR DESCRIPTION
These should be excluded from build all/solution, as they don't actually build anything and take very long time.