### PR TITLE
Search for clang-tidy without a version suffix

### DIFF
--- a/cmake/Findclang_tidy.cmake
+++ b/cmake/Findclang_tidy.cmake
@@ -13,6 +13,7 @@ find_program(clang_tidy_EXECUTABLE
         clang-tidy-3.8
         clang-tidy-3.9
         clang-tidy-4.0
+        clang-tidy
     PATHS
         "${CLANG_TIDY_DIR}"
 )


### PR DESCRIPTION
This is the naming scheme used by the llvm package in homebrew on macOS:
```bash
$ brew list llvm | grep tidy
/usr/local/Cellar/llvm/5.0.0/bin/clang-tidy
/usr/local/Cellar/llvm/5.0.0/share/clang/run-clang-tidy.py
/usr/local/Cellar/llvm/5.0.0/share/clang/clang-tidy-diff.py
```