### PR TITLE
[appveyor.yml] Simplify yaml syntax and fix watched file directories

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,5 +45,5 @@ only_commits:
   files:
     - CMakeLists.txt
     - appveyor.yml
-    - sources/
+    - source/
     - cmake/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,19 +31,16 @@ init:
 - echo %generator%
 
 before_build:
-- cmd: >-
+- cmd: |-
     mkdir build
-    
     cd build
-    
     cmake --version
-
     cmake .. -G %generator%
-    
+
 build:
   project: c:\projects\cmake-init\build\template.sln
   verbosity: minimal
-  parallel: true 
+  parallel: true
 only_commits:
   files:
     - CMakeLists.txt


### PR DESCRIPTION
As explained in [this well-written StackOverflow answer](https://stackoverflow.com/a/21699210/2560557), using `|-` allows us to write the commands without additional linebreaks in between.
Additionally, this PR fixes the list of watched files - there is only a `source`, not a `sources` directory.