### PR TITLE
Add possibility to build in nested folders

### DIFF
--- a/configure
+++ b/configure
@@ -104,7 +104,7 @@ echo "Configuring ..."
 echo ""
 
 # Create build directory
-if [ ! -d "./$BUILD_DIR" ]
+if [ ! -d "$BUILD_DIR" ]
 then
     mkdir -p "$BUILD_DIR"
 fi

--- a/configure
+++ b/configure
@@ -106,12 +106,13 @@ echo ""
 # Create build directory
 if [ ! -d "./$BUILD_DIR" ]
 then
-    mkdir $BUILD_DIR
+    mkdir -p "$BUILD_DIR"
 fi
 
 # Configure project
+PREVIOUS_DIR=$(pwd)
 cd $BUILD_DIR
-cmake -G "$CMAKE_GENERATOR" "-DCMAKE_BUILD_TYPE=$BUILD_TYPE" $CMAKE_OPTIONS ..
+cmake -G "$CMAKE_GENERATOR" "-DCMAKE_BUILD_TYPE=$BUILD_TYPE" $CMAKE_OPTIONS "$PREVIOUS_DIR"
 if [ $? == 0 ]
 then
     echo ""
@@ -123,4 +124,4 @@ else
     echo "Configuration failed.";
 fi
 
-cd ..
+cd "$PREVIOUS_DIR"


### PR DESCRIPTION
First of all a note: the `configure` script is awesome to use as a standalone script for other projects which are not based on *cmake-init*. However sometimes other projects require a setup with nested folders, e.g. expecting the build folder to be in `build/Release` or `build/Debug`.

These changes would allow the configure script to be used in these cases.