### PR TITLE
Remove unneeded CMP0028 policy setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 include(cmake/Custom.cmake)
 
 # Set policies
-set_policy(CMP0028 NEW) # ENABLE CMP0028: Double colon in target name means ALIAS or IMPORTED target.
 set_policy(CMP0054 NEW) # ENABLE CMP0054: Only interpret if() arguments as variables or keywords when unquoted.
 set_policy(CMP0042 NEW) # ENABLE CMP0042: MACOSX_RPATH is enabled by default.
 set_policy(CMP0063 NEW) # ENABLE CMP0063: Honor visibility properties for all target types.


### PR DESCRIPTION
Since `CMP0028` was introduced in CMake 3.0, and the minimum required version is `3.0`, there is
no need to explicit set the policy.

References:
* https://cmake.org/cmake/help/git-master/manual/cmake-policies.7.html#policies-introduced-by-cmake-3-0
* https://cmake.org/cmake/help/git-master/command/cmake_minimum_required.html