### PR TITLE
Add example to find library dependencies to configure script

### DIFF
--- a/template-config.cmake
+++ b/template-config.cmake
@@ -5,6 +5,11 @@
 # Please adjust the list of submodules to search for.
 
 
+# Find depencencies
+include(CMakeFindDependencyMacro)
+#find_dependency(glm)
+
+
 # List of modules
 set(MODULE_NAMES
     baselib
@@ -40,6 +45,7 @@ if(MODULE_FOUND)
     return()
 endif()
 
+
 # Try common build locations
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     find_modules("build-debug/cmake")
@@ -48,6 +54,7 @@ else()
     find_modules("build/cmake")
     find_modules("build-debug/cmake")
 endif()
+
 
 # Signal success/failure to CMake
 set(template_FOUND ${MODULE_FOUND})


### PR DESCRIPTION
Since CMake 3.0 there is a feature to search for dependencies of a target within the `-config.cmake` configure script.
This PR adds an example to our template.

An actual use can be seen in https://github.com/cginternals/globjects/pull/359.